### PR TITLE
support alternate aws partitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Available targets:
 | [aws_ssm_patch_group.scan_patchgroup](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_patch_group) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -40,6 +40,7 @@
 | [aws_ssm_patch_group.scan_patchgroup](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_patch_group) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -3,11 +3,11 @@ locals {
 }
 
 data "aws_caller_identity" "current" {
-  count    = local.enabled ? 1 : 0
+  count = local.enabled ? 1 : 0
 }
 
 data "aws_partition" "current" {
-  count    = local.enabled ? 1 : 0
+  count = local.enabled ? 1 : 0
 }
 
 module "scan_window_label" {

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,7 @@ locals {
 }
 
 data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
 
 module "scan_window_label" {
   source  = "cloudposse/label/null"

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,13 @@ locals {
   enabled = module.this.enabled
 }
 
-data "aws_caller_identity" "current" {}
-data "aws_partition" "current" {}
+data "aws_caller_identity" "current" {
+  count    = local.enabled ? 1 : 0
+}
+
+data "aws_partition" "current" {
+  count    = local.enabled ? 1 : 0
+}
 
 module "scan_window_label" {
   source  = "cloudposse/label/null"

--- a/ssm_log_bucket.tf
+++ b/ssm_log_bucket.tf
@@ -1,10 +1,10 @@
 locals {
   account_id        = data.aws_caller_identity.current.account_id
+  aws_partition     = data.aws_partition.current.partition
   create_log_bucket = local.enabled && var.bucket_id == null
   bucket_id         = var.bucket_id != null ? var.bucket_id : module.ssm_patch_log_s3_bucket_label.id
   bucket_policy     = var.ssm_bucket_policy != null ? var.ssm_bucket_policy : try(data.aws_iam_policy_document.bucket_policy[0].json, "")
 }
-
 
 module "ssm_patch_log_s3_bucket_label" {
   source  = "cloudposse/label/null"
@@ -26,12 +26,12 @@ data "aws_iam_policy_document" "bucket_policy" {
     ]
 
     resources = [
-      format("arn:aws:s3:::%s", module.ssm_patch_log_s3_bucket_label.id),
-      format("arn:aws:s3:::%s/*", module.ssm_patch_log_s3_bucket_label.id)
+      format("arn:%s:s3:::%s", local.aws_partition, module.ssm_patch_log_s3_bucket_label.id),
+      format("arn:%s:s3:::%s/*", local.aws_partition, module.ssm_patch_log_s3_bucket_label.id)
     ]
 
     principals {
-      identifiers = [format("arn:aws:iam::%s:root", local.account_id)]
+      identifiers = [format("arn:%s:iam::%s:root", local.aws_partition, local.account_id)]
       type        = "AWS"
     }
   }

--- a/ssm_log_bucket.tf
+++ b/ssm_log_bucket.tf
@@ -1,6 +1,6 @@
 locals {
-  account_id        = data.aws_caller_identity.current.account_id
-  aws_partition     = data.aws_partition.current.partition
+  account_id        = join("", data.aws_caller_identity.current.*.account_id)
+  aws_partition     = join("", data.aws_partition.current.*.partition)
   create_log_bucket = local.enabled && var.bucket_id == null
   bucket_id         = var.bucket_id != null ? var.bucket_id : module.ssm_patch_log_s3_bucket_label.id
   bucket_policy     = var.ssm_bucket_policy != null ? var.ssm_bucket_policy : try(data.aws_iam_policy_document.bucket_policy[0].json, "")

--- a/ssm_log_bucket.tf
+++ b/ssm_log_bucket.tf
@@ -6,6 +6,7 @@ locals {
   bucket_policy     = var.ssm_bucket_policy != null ? var.ssm_bucket_policy : try(data.aws_iam_policy_document.bucket_policy[0].json, "")
 }
 
+
 module "ssm_patch_log_s3_bucket_label" {
   source  = "cloudposse/label/null"
   version = "0.25.0"


### PR DESCRIPTION
## what
- dynamically set the aws partition when constructing ARNs

## why
- hardcoded aws partitions make govcloud users sad

