### PR TITLE
update(ssm_log_bucket): use source_policy_documents

### DIFF
--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ssm-patch-manager&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ssm-patch-manager&utm_content=website
@@ -445,3 +445,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-ssm-patch-manager
   [share_email]: mailto:?subject=terraform-aws-ssm-patch-manager&body=https://github.com/cloudposse/terraform-aws-ssm-patch-manager
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-ssm-patch-manager?pixel&cs=github&cm=readme&an=terraform-aws-ssm-patch-manager
+<!-- markdownlint-restore -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -28,7 +28,7 @@ module "ec2_instance" {
   vpc_id          = module.vpc.vpc_id
   subnet          = module.subnets.private_subnet_ids[0]
   security_groups = [module.vpc.vpc_default_security_group_id]
-  ami             = "ami-009b28ad8707b9ee8"
+  ami             = "ami-0b0dcb5067f052a63"
   ami_owner       = "amazon"
   ssh_key_pair    = ""
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -28,7 +28,7 @@ module "ec2_instance" {
   vpc_id          = module.vpc.vpc_id
   subnet          = module.subnets.private_subnet_ids[0]
   security_groups = [module.vpc.vpc_default_security_group_id]
-  ami             = "ami-0b0dcb5067f052a63"
+  ami             = "ami-0beaa649c482330f7"
   ami_owner       = "amazon"
   ssh_key_pair    = ""
 

--- a/ssm_log_bucket.tf
+++ b/ssm_log_bucket.tf
@@ -43,8 +43,8 @@ module "ssm_patch_log_s3_bucket" {
   source  = "cloudposse/s3-bucket/aws"
   version = "2.0.0"
 
-  acl                = "private"
-  versioning_enabled = var.ssm_bucket_versioning_enable
-  policy             = local.bucket_policy
-  context            = module.ssm_patch_log_s3_bucket_label.context
+  acl                     = "private"
+  versioning_enabled      = var.ssm_bucket_versioning_enable
+  source_policy_documents = [local.bucket_policy]
+  context                 = module.ssm_patch_log_s3_bucket_label.context
 }


### PR DESCRIPTION
## what
* using `source_policy_documents` for bucket policy


## why
* bucket was created, but no policy was applied

## references
* Use `closes #21` https://github.com/cloudposse/terraform-aws-ssm-patch-manager/issues/21

