### PR TITLE
Use `t3.micro` for tests

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -31,6 +31,7 @@ module "ec2_instance" {
   ami             = "ami-0beaa649c482330f7"
   ami_owner       = "amazon"
   ssh_key_pair    = ""
+  instance_type   = "t3.micro"
 
   # Enabling SSM Patch manager policy, access to the log bucket and the additional tags
   ssm_patch_manager_enabled       = true


### PR DESCRIPTION
## what
* Use `t3.micro` for tests

## Why
* Cloudposse test infrastructure denied `Non Nitro` instances  

## References
* https://raw.githubusercontent.com/cloudposse/terraform-aws-service-control-policies/0.9.2/catalog/ec2-policies.yaml